### PR TITLE
モーターライブラリの修正

### DIFF
--- a/Arduino_programs/ModuleTest/ModuleTest/TestPrograms.ino
+++ b/Arduino_programs/ModuleTest/ModuleTest/TestPrograms.ino
@@ -94,27 +94,27 @@ class Motor : public AbstructProgram
           break;
         case '9':
           Serial.println(F("rightForward"));
-          omuni.rightForward(speed, timeDelay);
+          omuni.rightForward(this->speed, timeDelay);
           break;
         case '3':
           Serial.println(F("rightBackward"));
-          omuni.rightBackward(speed, timeDelay);
+          omuni.rightBackward(this->speed, timeDelay);
           break;
         case '7':
           Serial.println(F("leftForward"));
-          omuni.leftForward(speed, timeDelay);
+          omuni.leftForward(this->speed, timeDelay);
           break;
         case '1':
           Serial.println(F("leftBackward"));
-          omuni.leftBackward(speed, timeDelay);
+          omuni.leftBackward(this->speed, timeDelay);
           break;
         case '*':
           Serial.println(F("turnRight"));
-          omuni.turnRight(speed, timeDelay);
+          omuni.turnRight(this->speed, timeDelay);
           break;
         case '/':
           Serial.println(F("turnLeft"));
-          omuni.turnLeft(speed, timeDelay);
+          omuni.turnLeft(this->speed, timeDelay);
           break;
         case '5':
           Serial.println(F("full stop"));

--- a/Arduino_programs/libraries/L298N_omuni/L298N_omuni.cpp
+++ b/Arduino_programs/libraries/L298N_omuni/L298N_omuni.cpp
@@ -11,16 +11,12 @@ setupMotor、driveMotor関数を直接使用することで、モーターを好
 #include "Arduino.h"
 #include "L298N_omuni.h"
 
-struct Motor {
-	int in1;
-	int in2;
-	int pwm;
-};
-
-Motor motors[4];
-
 L298N_omuni::L298N_omuni(int A_ena, int A_in1, int A_in2, int A_in3, int A_in4, int A_enb,
 						 int B_ena, int B_in1, int B_in2, int B_in3, int B_in4, int B_enb)
+	: _motors{	{ A_in1, A_in2, A_ena },
+				{ A_in3, A_in4, A_enb },
+				{ B_in1, B_in2, B_ena },
+				{ B_in3, B_in4, B_enb } }
 {
 	pinMode(A_ena, OUTPUT);
 	pinMode(A_in1, OUTPUT);
@@ -35,22 +31,6 @@ L298N_omuni::L298N_omuni(int A_ena, int A_in1, int A_in2, int A_in3, int A_in4, 
 	pinMode(B_in3, OUTPUT);
 	pinMode(B_in4, OUTPUT);
 	pinMode(B_enb, OUTPUT);
-
-	motors[0].in1 = A_in1;
-	motors[0].in2 = A_in2;
-	motors[0].pwm = A_ena;
-
-	motors[1].in1 = A_in3;
-	motors[1].in2 = A_in4;
-	motors[1].pwm = A_enb;
-
-	motors[2].in1 = B_in1;
-	motors[2].in2 = B_in2;
-	motors[2].pwm = B_ena;
-
-	motors[3].in1 = B_in3;
-	motors[3].in2 = B_in4;
-	motors[3].pwm = B_enb;
 }
 
 /*
@@ -147,8 +127,8 @@ void L298N_omuni::setupMotors(byte state)
 
 void L298N_omuni::setupMotor(int motorIndex, int state1, int state2)
 {
-	digitalWrite(motors[motorIndex].in1, state1);
-	digitalWrite(motors[motorIndex].in2, state2);
+	digitalWrite(_motors[motorIndex].in1, state1);
+	digitalWrite(_motors[motorIndex].in2, state2);
 }
 
 void L298N_omuni::driveMotors(int speed)
@@ -160,5 +140,5 @@ void L298N_omuni::driveMotors(int speed)
 }
 void L298N_omuni::driveMotor(int motorIndex, int speed)
 {
-	analogWrite(motors[motorIndex].pwm, speed);
+	analogWrite(_motors[motorIndex].pwm, speed);
 }

--- a/Arduino_programs/libraries/L298N_omuni/L298N_omuni.cpp
+++ b/Arduino_programs/libraries/L298N_omuni/L298N_omuni.cpp
@@ -4,15 +4,14 @@ Create : 2016/12/02
 Author : R. Hirayama
 Board  : Arduino Due
 feture :
-2‚Â‚ÌL298N‚Å4ŒÂ‚Ìƒ‚[ƒ^[‚ð§Œä‚µ‚Ü‚·B
-‚ ‚ç‚©‚¶‚ß‘OŒã¶‰EA¶‰EŽÎ‚ß‘OEŒã‚ëA¶‰Eù‰ñ‚ªŠÈ’P‚Éo—ˆ‚é—l‚É‚È‚Á‚Ä‚¢‚Ü‚·B
-setupMotorAdriveMotorŠÖ”‚ð’¼ÚŽg—p‚·‚é‚±‚Æ‚ÅAƒ‚[ƒ^[‚ðD‚«‚È‚æ‚¤‚É“®‚©‚¹‚Ü‚·B
+2ã¤ã®L298Nã§4å€‹ã®ãƒ¢ãƒ¼ã‚¿ãƒ¼ã‚’åˆ¶å¾¡ã—ã¾ã™ã€‚
+ã‚ã‚‰ã‹ã˜ã‚å‰å¾Œå·¦å³ã€å·¦å³æ–œã‚å‰ãƒ»å¾Œã‚ã€å·¦å³æ—‹å›žãŒç°¡å˜ã«å‡ºæ¥ã‚‹æ§˜ã«ãªã£ã¦ã„ã¾ã™ã€‚
+setupMotorã€driveMotoré–¢æ•°ã‚’ç›´æŽ¥ä½¿ç”¨ã™ã‚‹ã“ã¨ã§ã€ãƒ¢ãƒ¼ã‚¿ãƒ¼ã‚’å¥½ããªã‚ˆã†ã«å‹•ã‹ã›ã¾ã™ã€‚
 */
 #include "Arduino.h"
 #include "L298N_omuni.h"
 
-struct Motor
-{
+struct Motor {
 	int in1;
 	int in2;
 	int pwm;
@@ -21,7 +20,7 @@ struct Motor
 Motor motors[4];
 
 L298N_omuni::L298N_omuni(int A_ena, int A_in1, int A_in2, int A_in3, int A_in4, int A_enb,
-	int B_ena, int B_in1, int B_in2, int B_in3, int B_in4, int B_enb)
+						 int B_ena, int B_in1, int B_in2, int B_in3, int B_in4, int B_enb)
 {
 	pinMode(A_ena, OUTPUT);
 	pinMode(A_in1, OUTPUT);
@@ -55,7 +54,7 @@ L298N_omuni::L298N_omuni(int A_ena, int A_in1, int A_in2, int A_in3, int A_in4, 
 }
 
 /*
-–kA“Œ‚ð³‚Æ‚·‚é
+åŒ—ã€æ±ã‚’æ­£ã¨ã™ã‚‹
 NSEW
 N_in1,N_in2,S_in1,S_in2,E_in1,E_in2,W_in1,W_in2
 */
@@ -136,15 +135,14 @@ void L298N_omuni::fullStop(int delay_time)
 	delay(delay_time);
 }
 
-
-//ˆø”‚É8ƒrƒbƒg‚Ì“ñi”‚ð“ü—Í@char‚ðƒ‚[ƒ^‚ÌHigh Low§Œä‚ÉŠ„‚è“–‚Ä‚½B
-//0,1ƒrƒbƒg–Ú‚ª–k@2,3ƒrƒbƒg–Ú‚ª“ìA4,5ƒrƒbƒg–Ú‚ª“ŒA6,7ƒrƒbƒg–Ú‚ª¼
-void L298N_omuni::setupMotors(unsigned char& state)
+//å¼•æ•°ã«8ãƒ“ãƒƒãƒˆã®äºŒé€²æ•°ã‚’å…¥åŠ›ã€€charã‚’ãƒ¢ãƒ¼ã‚¿ã®High Lowåˆ¶å¾¡ã«å‰²ã‚Šå½“ã¦ãŸã€‚
+//0,1ãƒ“ãƒƒãƒˆç›®ãŒåŒ—ã€€2,3ãƒ“ãƒƒãƒˆç›®ãŒå—ã€4,5ãƒ“ãƒƒãƒˆç›®ãŒæ±ã€6,7ãƒ“ãƒƒãƒˆç›®ãŒè¥¿
+void L298N_omuni::setupMotors(byte state)
 {
-	L298N_omuni::setupMotor(this->MOTOR_N, state & B1, state & B10);
-	L298N_omuni::setupMotor(this->MOTOR_S, state & B100, state & B1000);
-	L298N_omuni::setupMotor(this->MOTOR_E, state & B10000, state & B1000000);
-	L298N_omuni::setupMotor(this->MOTOR_W, state & B1000000, state& B100000000);
+	L298N_omuni::setupMotor(this->MOTOR_N, state & B00000001, state & B00000010);
+	L298N_omuni::setupMotor(this->MOTOR_S, state & B00000100, state & B00001000);
+	L298N_omuni::setupMotor(this->MOTOR_E, state & B00010000, state & B00100000);
+	L298N_omuni::setupMotor(this->MOTOR_W, state & B01000000, state & B10000000);
 }
 
 void L298N_omuni::setupMotor(int motorIndex, int state1, int state2)

--- a/Arduino_programs/libraries/L298N_omuni/L298N_omuni.h
+++ b/Arduino_programs/libraries/L298N_omuni/L298N_omuni.h
@@ -5,9 +5,9 @@ Create : 2016/12/02
 Author : R. Hirayama
 Board  : Arduino Due
 feture :
-2��L298N��4�̃��[�^�[�𐧌䂵�܂��B
-���炩���ߑO�㍶�E�A���E�΂ߑO�E���A���E���񂪊ȒP�ɏo����l�ɂȂ��Ă��܂��B
-setupMotor�AdriveMotor�֐��𒼐ڎg�p���邱�ƂŁA���[�^�[���D���Ȃ悤�ɓ������܂��B
+2つのL298Nで4個のモーターを制御します。
+あらかじめ前後左右、左右斜め前・後ろ、左右旋回が簡単に出来る様になっています。
+setupMotor、driveMotor関数を直接使用することで、モーターを好きなように動かせます。
 */
 #ifndef _L298N_OMUNI_h
 #define _L298N_OMUNI_h
@@ -18,12 +18,12 @@ class L298N_omuni
 {
 public:
 	static const int MOTOR_N = 0;
-	static const int MOTOR_S = 0;
-	static const int MOTOR_E = 0;
-	static const int MOTOR_W = 0;
+	static const int MOTOR_S = 1;
+	static const int MOTOR_E = 2;
+	static const int MOTOR_W = 3;
 
 	L298N_omuni(int A_ena, int A_in1, int A_in2, int A_in3, int A_in4, int A_enb,
-		int B_ena, int B_in1, int B_in2, int B_in3, int B_in4, int B_enb);
+				int B_ena, int B_in1, int B_in2, int B_in3, int B_in4, int B_enb);
 
 	void forward(int speed, int delay_time);
 	void backward(int speed, int delay_time);
@@ -43,7 +43,7 @@ public:
 
 	void driveMotors(int speed);
 	void driveMotor(int motor_index, int speed);
-	void setupMotors(int state1, int state2, int state3, int state4, int state5, int state6, int state7, int state8);
+	void setupMotors(byte state);
 	void setupMotor(int motor_index, int state1, int state2);
 
 private:
@@ -61,32 +61,5 @@ private:
 	int _B_in4;
 	int _B_enb;
 };
-
-static void L298N_omuni::setupMotors(int state1, int state2, int state3, int state4, int state5, int state6, int state7, int state8)
-{
-	L298N_omuni::setupMotor(this->MOTOR_N, state1, state2);
-	L298N_omuni::setupMotor(this->MOTOR_S, state3, state4);
-	L298N_omuni::setupMotor(this->MOTOR_E, state5, state6);
-	L298N_omuni::setupMotor(this->MOTOR_W, state7, state8);
-}
-
-static void L298N_omuni::setupMotor(int motorIndex, int state1, int state2)
-{
-	digitalWrite(motors[motorIndex].in1, state1);
-	digitalWrite(motors[motorIndex].in2, state2);
-}
-
-static void L298N_omuni::driveMotors(int speed)
-{
-	this->driveMotor(this->MOTOR_N, speed);
-	this->driveMotor(this->MOTOR_S, speed);
-	this->driveMotor(this->MOTOR_E, speed);
-	this->driveMotor(this->MOTOR_W, speed);
-}
-static void L298N_omuni::driveMotor(int motorIndex, int speed)
-{
-	analogWrite(motors[motorIndex].pwm, speed);
-}
-
 
 #endif

--- a/Arduino_programs/libraries/L298N_omuni/L298N_omuni.h
+++ b/Arduino_programs/libraries/L298N_omuni/L298N_omuni.h
@@ -14,8 +14,7 @@ setupMotor、driveMotor関数を直接使用することで、モーターを好
 
 #include "Arduino.h"
 
-class L298N_omuni
-{
+class L298N_omuni {
 public:
 	static const int MOTOR_N = 0;
 	static const int MOTOR_S = 1;
@@ -47,19 +46,13 @@ public:
 	void setupMotor(int motor_index, int state1, int state2);
 
 private:
-	struct Motor;
-	int _A_ena;
-	int _A_in1;
-	int _A_in2;
-	int _A_in3;
-	int _A_in4;
-	int _A_enb;
-	int _B_ena;
-	int _B_in1;
-	int _B_in2;
-	int _B_in3;
-	int _B_in4;
-	int _B_enb;
+	struct Motor {
+		int in1;
+		int in2;
+		int pwm;
+	};
+
+	L298N_omuni::Motor _motors[4];
 };
 
 #endif

--- a/Arduino_programs/libraries/L298N_omuni/L298N_omuni.h
+++ b/Arduino_programs/libraries/L298N_omuni/L298N_omuni.h
@@ -52,7 +52,7 @@ private:
 		int pwm;
 	};
 
-	L298N_omuni::Motor _motors[4];
+	const L298N_omuni::Motor _motors[4];
 };
 
 #endif


### PR DESCRIPTION
# 変更点
+ setupMotorsの引数unsigned char& をbyte に変更
+ L298N_omuniのメンバ変数がいくつか使われていなかったため除去
+ 構造体MotorをL298N_omuniのメンバ(private)として実装
+ motorsがグローバル変数として宣言されていたため、L298N_omuniのメンバ変数(private, const)として宣言

# プログラムについて
コンパイルを通しただけなので、実際の環境で動くかはわかりません。
明日モーターを使ってテストします。
